### PR TITLE
Set up Continuous Integration

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -1,0 +1,61 @@
+name: Build and push container image
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Podman
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y podman
+
+      - name: Log into the container registry
+        if: github.event_name != 'pull_request'
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Build the container image
+        run: |
+          # Container image identifiers must be all-lowercase.
+          # The two commas transform "User/OSMExpress" to "user/osmexpress".
+          IMAGE_ID=ghcr.io/${GITHUB_REPOSITORY,,}
+          SHA_TAG=${{ github.sha }}
+          LATEST_TAG=latest
+
+          # Build the container image with SHA and latest tags.
+          podman build -t ${IMAGE_ID}:${SHA_TAG} -t ${IMAGE_ID}:${LATEST_TAG} .
+
+          # If this is a release event, tag the image with the release tag.
+          if [ "${{ github.event_name }}" = "release" ]; then
+            RELEASE_TAG=${{ github.event.release.tag_name }}
+            podman tag ${IMAGE_ID}:${SHA_TAG} ${IMAGE_ID}:${RELEASE_TAG}
+          fi
+
+      - name: Push the container image to the registry
+        if: github.event_name != 'pull_request'
+        run: |
+          IMAGE_ID=ghcr.io/${GITHUB_REPOSITORY,,}
+          SHA_TAG=${{ github.sha }}
+          LATEST_TAG=latest
+
+          # Push the container image with SHA and latest tags.
+          podman push $IMAGE_ID:$SHA_TAG
+          podman push $IMAGE_ID:$LATEST_TAG
+
+          # If this is a release event, push the image with the release tag.
+          if [ "${{ github.event_name }}" = "release" ]; then
+            RELEASE_TAG=${{ github.event.release.tag_name }}
+            podman push $IMAGE_ID:$RELEASE_TAG
+          fi


### PR DESCRIPTION
For pull requests, we try to build the container. This also runs unit tests due to how the Dockerfile is set up. GitHub will display the build status on its review page for the pull request. If the build (and tests that are run as part of the build) succeeded, the icon is green. If it failed, the icon is red.

For changes to the main branch, we build the container and push it to the GitHub container registry. Once this change is part of the main repo and GitHub had a chance to run the corresponding workflow for the first time, users can use one of the following commands to fetch the latest container, depending on whether they prefer docker (which needs installation of proprietary software) or podman (which is open source):

```sh
$ docker pull ghcr.io/bdon/osmexpress:latest
$ podman pull ghcr.io/bdon/osmexpress:latest
```

The full list of `osmexpress` containers will be available from [this page](https://github.com/bdon/OSMExpress/pkgs/container/osmexpress).